### PR TITLE
[DDCI-217] - disable active class for button

### DIFF
--- a/ckanext/spatial/public/js/spatial_query.js
+++ b/ckanext/spatial/public/js/spatial_query.js
@@ -415,7 +415,7 @@ this.ckan.module('spatial-query', function ($, _) {
       }
 
       function toggleCoordinateForm(event) {
-        $(event.target).toggleClass('active').parent().toggleClass('active');
+        $(event.target).parent().toggleClass('active');
 
         if (module.options.draw_default && module.options.default_extent) {
           if (!default_drawn && !extentLayer) {


### PR DESCRIPTION
https://it-partners.atlassian.net/browse/DDCI-217

the "Enter coordinate" button has an `.active` class when it is selected, but unfortunately `.active` style on the QLD style guide is similar to the normal state (which already implemented on QDES CKAN), and it is still failing QA. 

so in this PR is to remove the active class from button until we have FE ticket for the spatial map.

