### PR TITLE
[DDCI-181] - updated to use padding instead

### DIFF
--- a/ckanext/spatial/public/js/dataset_map.js
+++ b/ckanext/spatial/public/js/dataset_map.js
@@ -74,10 +74,11 @@ this.ckan.module('dataset-map', function (jQuery, _) {
       if (this.extent.type == 'Point'){
         map.setView(L.latLng(this.extent.coordinates[1], this.extent.coordinates[0]), 9);
       } else {
-        map.fitBounds(extentLayer.getBounds());
-
-        if (this.options.map_config.map_zoom) {
-          map.setZoom(this.options.map_config.map_zoom);
+        if (this.options.map_config.padding) {
+          map.fitBounds(extentLayer.getBounds(), {padding: this.options.map_config.padding});
+        }
+        else {
+          map.fitBounds(extentLayer.getBounds());
         }
       }
     }


### PR DESCRIPTION
I updated from zoom to padding instead. zoom is not working well because if you have box too small, the zoom will too zoom out, and even smaller.

the padding will go to the closer zoom out level