### PR TITLE
Updated ckan CONTRIBUTING link from rst to md in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Contributing
 
 For contributing to ckanext-spatial or its documentation, follow the same
 guidelines that apply to CKAN core, described in
-`CONTRIBUTING <https://github.com/okfn/ckan/blob/master/CONTRIBUTING.rst>`_.
+`CONTRIBUTING <https://github.com/ckan/ckan/blob/master/CONTRIBUTING.md>`_.
 
 
 Copying and License


### PR DESCRIPTION
The `CONTRIBUTING` link in the `README` is `https://github.com/okfn/ckan/blob/master/CONTRIBUTING.rst` but that was changed to `https://github.com/ckan/ckan/blob/master/CONTRIBUTING.md` in `https://github.com/ckan/ckan/commit/b03de03f06db652434f5a9da7b34570574797371`. Changing from `rst` to `md` so the link works.